### PR TITLE
Fix system name in assets

### DIFF
--- a/packages/systems/assets/systems.json
+++ b/packages/systems/assets/systems.json
@@ -891,7 +891,7 @@
         "whClass": null
     },
     {
-        "name": 0,
+        "name": "6E-578",
         "id": 30003270,
         "securityStatus": -0.05088454712950252,
         "securityClass": "NULL",


### PR DESCRIPTION
Not sure where you're pulling system names from but 6E-578 was `0` in the data for some reason.