### PR TITLE
Add missing wh classes, export types

### DIFF
--- a/packages/systems/src/api/system.type.ts
+++ b/packages/systems/src/api/system.type.ts
@@ -30,9 +30,13 @@ export type System = {
   regionId: number;
 
   /**
-   * Class (1-6) for wormhole systems, `null` for others.
+   * Class (1-6) for wormhole systems
+   * Class 12 for Thera
+   * Class 13 for Shattered systems
+   * Class 25 for Pochven
+   * `null` for others.
    */
-  whClass: 1 | 2 | 3 | 4 | 5 | 6 | null;
+  whClass: 1 | 2 | 3 | 4 | 5 | 6 | 12 | 13 | 25 | null;
 };
 
 export type WormholeEffect = {

--- a/packages/systems/src/main.ts
+++ b/packages/systems/src/main.ts
@@ -2,6 +2,8 @@ import systemsData from "../assets/systems.json";
 import findOneSystemApi from "./api/findOneSystem";
 import { System } from "./api/system.type";
 
+export * from "./api/system.type";
+
 const systems: System[] = systemsData;
 
 /**


### PR DESCRIPTION
This pr includes missing wormhole classes (12, 13, 25) in the System type, and exports types.

Note on wormhole classes: although `system.whClass` can express 12, 13, and 25, the effect of C13s are C6 WR, there are no missing effect classes.